### PR TITLE
feat: remove bluebird

### DIFF
--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -57,21 +57,22 @@ export default class AsyncConnect extends Component {
     const store = this.context.store;
     const loadResult = loadAsyncConnect({ ...props, store });
 
+    // TODO: think of a better solution to a problem?
     this.loadDataCounter++;
     this.props.beginGlobalLoad();
-    (loadDataCounterOriginal => {
-      loadResult.then(() => {
-        // We need to change propsToShow only if loadAsyncData that called this promise
-        // is the last invocation of loadAsyncData method. Otherwise we can face situation
-        // when user is changing route several times and we finally show him route that has
-        // loaded props last time and not the last called route
-        if (this.loadDataCounter === loadDataCounterOriginal) {
-          this.setState({ propsToShow: props });
-        }
+    return (loadDataCounterOriginal => loadResult.then(() => {
+      // We need to change propsToShow only if loadAsyncData that called this promise
+      // is the last invocation of loadAsyncData method. Otherwise we can face situation
+      // when user is changing route several times and we finally show him route that has
+      // loaded props last time and not the last called route
+      if (this.loadDataCounter === loadDataCounterOriginal) {
+        this.setState({ propsToShow: props });
+      }
 
-        this.props.endGlobalLoad();
-      });
-    })(this.loadDataCounter);
+      // TODO: investigate race conditions
+      // do we need to call this if it's not last invocation?
+      this.props.endGlobalLoad();
+    }))(this.loadDataCounter);
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
   },
   "dependencies": {
     "redux-actions": "^0.9.1",
-    "babel-runtime": "~6.x.x",
-    "bluebird": "~3.x.x"
+    "babel-runtime": "~6.x.x"
   },
   "jest": {
     "automock": false,


### PR DESCRIPTION
* adds more tests for async actions, calls on beginGlobalLoad & endGlobalLoad
* if Promise.mapSeries is not available - falls back to own implementation
* loadAsyncData returns promise for tracking purposes