### PR TITLE
Fix case where no component uses @asyncConnect

### DIFF
--- a/modules/helpers/utils.js
+++ b/modules/helpers/utils.js
@@ -79,6 +79,10 @@ export function filterAndFlattenComponents(components) {
 export function loadAsyncConnect({ components, filter = () => true, ...rest }) {
   const flattened = filterAndFlattenComponents(components);
 
+  if (flattened.length === 0) {
+    return Promise.resolve();
+  }
+
   // this allows us to have nested promises, that rely on each other's completion
   // cycle
   return mapSeries(flattened, component => {


### PR DESCRIPTION
First of all, amazing job on continuing the project and doing a major update+refac. I just realised one problem: when there isn't any connected component (via @asyncConnect), the function *loadOnServer* breaks. I fixed that by returning an empty Promise.

```
[Unhandled Promise Rejection] TypeError
	[Stack]
	 TypeError: Cannot read property 'reduxAsyncConnect' of undefined
    at /Users/eliseumds/war/git/productreview/node_modules/redux-connect/lib/helpers/utils.js:130:31
    at iterateOverResults (/Users/eliseumds/war/git/productreview/node_modules/redux-connect/lib/helpers/utils.js:52:12)
    at run (/Users/eliseumds/war/git/productreview/node_modules/core-js/modules/es6.promise.js:89:22)
    at /Users/eliseumds/war/git/productreview/node_modules/core-js/modules/es6.promise.js:102:28
    at flush (/Users/eliseumds/war/git/productreview/node_modules/core-js/modules/_microtask.js:18:9)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
