### PR TITLE
feat: extended asyncConnect decorator

### DIFF
--- a/docs/API.MD
+++ b/docs/API.MD
@@ -22,6 +22,13 @@ Any helpers you may want pass to your reduxAsyncConnect static method.
 For example some fetching library.
 
 ## asyncConnect decorator
+
+```js
+asyncConnect(AsyncProps: Array, mapStateToProps?, mapDispatchToProps?, mergeProps?, options?)
+```
+
+Signature now corresponds to [react-redux connect](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
+
 This is the function that uses to decorate your container components that is connected with router.
 It should provide mapStateToProps object like that:
 

--- a/modules/containers/decorator.js
+++ b/modules/containers/decorator.js
@@ -43,7 +43,7 @@ function wrapWithDispatch(asyncItems) {
  * @param  {Function} [mapStateToProps]
  * @param  {Object|Function} [mapDispatchToProps]
  * @param  {Function} [mergeProps]
- * @param  {Object} options
+ * @param  {Object} [options]
  * @return {Function}
  */
 export function asyncConnect(asyncItems, mapStateToProps, mapDispatchToProps, mergeProps, options) {

--- a/modules/containers/decorator.js
+++ b/modules/containers/decorator.js
@@ -37,12 +37,21 @@ function wrapWithDispatch(asyncItems) {
   });
 }
 
-export function asyncConnect(asyncItems) {
+/**
+ * Exports decorator, which wraps React components with asyncConnect and connect at the same time
+ * @param  {Array} asyncItems
+ * @param  {Function} [mapStateToProps]
+ * @param  {Object|Function} [mapDispatchToProps]
+ * @param  {Function} [mergeProps]
+ * @param  {Object} options
+ * @return {Function}
+ */
+export function asyncConnect(asyncItems, mapStateToProps, mapDispatchToProps, mergeProps, options) {
   return Component => {
     Component.reduxAsyncConnect = wrapWithDispatch(asyncItems);
 
-    const finalMapStateToProps = state => (
-      asyncItems.reduce((result, { key }) => {
+    const finalMapStateToProps = (state, ownProps) => {
+      const asyncStateToProps = asyncItems.reduce((result, { key }) => {
         if (!key) {
           return result;
         }
@@ -51,9 +60,18 @@ export function asyncConnect(asyncItems) {
           ...result,
           [key]: state.reduxAsyncConnect[key],
         };
-      }, {})
-    );
+      }, {});
 
-    return connect(finalMapStateToProps)(Component);
+      if (typeof mapStateToProps !== 'function') {
+        return asyncStateToProps;
+      }
+
+      return {
+        ...mapStateToProps(state, ownProps),
+        ...asyncStateToProps,
+      };
+    };
+
+    return connect(finalMapStateToProps, mapDispatchToProps, mergeProps, options)(Component);
   };
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
-    "babel-runtime": "^6.6.1",
     "bluebird": "^3.3.3",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",


### PR DESCRIPTION
Now supports additional props, removing the need to use both `connect` and `asyncConnect`
decorators

Decorator now has the following signature:

`asyncConnect(AsyncProps: Array, mapStateToProps?, mapDispatchToProps?, mergeProps?, options?)`