### PR TITLE
Execute promises for keyed but unloaded decorators in onComponentMount

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
     "bluebird": "^3.3.3",
+    "deep-get-set": "^1.0.0",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",


### PR DESCRIPTION
Fixes https://github.com/makeomatic/redux-connect/issues/30

deep-get-set is optional here, but it makes one line golf-able. I can refactor if desired.