### PR TITLE
Log any exception when doing loadAsyncData

### DIFF
--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -78,8 +78,8 @@ export default class AsyncConnect extends Component {
       // TODO: investigate race conditions
       // do we need to call this if it's not last invocation?
       this.props.endGlobalLoad();
-    }).catch( (e) => {
-      console.error("Exception caught by ReduxAsyncConnect: ", e.stack);
+    }).catch((e) => {
+      console.error('Exception caught by ReduxAsyncConnect: ', e.stack);
     }))(this.loadDataCounter);
   }
 

--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -78,6 +78,8 @@ export default class AsyncConnect extends Component {
       // TODO: investigate race conditions
       // do we need to call this if it's not last invocation?
       this.props.endGlobalLoad();
+    }).catch( (e) => {
+      console.error("Exception caught by ReduxAsyncConnect: ", e.stack);
     }))(this.loadDataCounter);
   }
 

--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -79,7 +79,7 @@ export default class AsyncConnect extends Component {
       // do we need to call this if it's not last invocation?
       this.props.endGlobalLoad();
     }).catch((e) => {
-      console.error('Exception caught by ReduxAsyncConnect: ', e.stack);
+      console.error('Exception caught by ReduxAsyncConnect: ', e.stack || e.toString());
     }))(this.loadDataCounter);
   }
 


### PR DESCRIPTION
the `setState` in the promise would trigger a view re-render. If there're any exception happens after the data loaded & rendering the new view, this exception would be taken by the Promise. Therefore, it would appear fine but indeed.. users would see an empty screen because the view is not rendered properly due to exception.

This pull request tells the user that the exceptions happened indeed, and points to the developer where exactly is the exception (by logging the stack trace)