### PR TITLE
Added ability to use immutable stores

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -144,6 +144,46 @@ you use
 const render = applyRouterMiddleware(...middleware);
 ```
 
+## Usage with `ImmutableJS`
+
+This lib can be used with ImmutableJS or any other immutability lib by providing methods that convert the state between mutable and immutable data.
+
+```js
+import { setToImmutableStateFunc, setToMutableStateFunc } from 'redux-connect';
+
+// Set the mutability/immutability functions
+setToImmutableStateFunc((mutableState) => Immutable.fromJS(mutableState));
+setToMutableStateFunc((immutableState) => immutableState.toJS());
+
+// Thats all, now just use redux-connect as normal
+```
+
+**React Router Issue**
+
+While using the above immutablejs solution, an issue arose causing infinite recursion after firing
+off a react standard action. The recursion was caused because the `componentWillReceiveProps` method will attempt to resync with the server. Thus `componentWillReceiveProps -> resync with server -> changes props via reducer -> componentWillReceiveProps`
+
+The solution was to only resync with server on route changes. A `reloadOnPropsChange` prop is expose on the ReduxAsyncConnect component to allow customization of when a resync to the server should occur.
+
+Method signature `(props, nextProps) => bool`
+
+```js
+const reloadOnPropsChange = (props, nextProps) => {
+  // reload only when path/route has changed
+  return props.location.pathname !== nextProps.location.pathname;
+};
+
+export const Root = ({ store, history }) => (
+  <Provider store={store} key="provider">
+    <Router render={(props) => <ReduxAsyncConnect {...props}
+      reloadOnPropsChange={reloadOnPropsChange}/>} history={history}>
+      {getRoutes(store)}
+    </Router>
+  </Provider>
+);
+```
+
+
 ## Comparing with other libraries
 
 There are some solutions of problem described above:

--- a/README.MD
+++ b/README.MD
@@ -146,16 +146,20 @@ const render = applyRouterMiddleware(...middleware);
 
 ## Usage with `ImmutableJS`
 
-This lib can be used with ImmutableJS or any other immutability lib by providing methods that convert the state between mutable and immutable data.
+This lib can be used with ImmutableJS or any other immutability lib by providing methods that convert the state between mutable and immutable data. Along with those methods, there is also a special immutable reducer that needs to be used instead of the normal reducer.
 
 ```js
-import { setToImmutableStateFunc, setToMutableStateFunc } from 'redux-connect';
+import { setToImmutableStateFunc, setToMutableStateFunc, immutableReducer as reduxAsyncConnect } from 'redux-connect';
 
 // Set the mutability/immutability functions
 setToImmutableStateFunc((mutableState) => Immutable.fromJS(mutableState));
 setToMutableStateFunc((immutableState) => immutableState.toJS());
 
 // Thats all, now just use redux-connect as normal
+export const rootReducer = combineReducers({
+  reduxAsyncConnect,
+  ...
+})
 ```
 
 **React Router Issue**

--- a/__tests__/redux-connect.spec.js
+++ b/__tests__/redux-connect.spec.js
@@ -16,6 +16,7 @@ import AsyncConnect from '../modules/components/AsyncConnect';
 import {
   asyncConnect,
   reducer as reduxAsyncConnect,
+  immutableReducer,
   loadOnServer,
 } from '../modules/index';
 
@@ -254,7 +255,9 @@ describe('<ReduxAsyncConnect />', function suite() {
 
   pit('properly fetches data on the server when using immutable data structures', function test() {
     // We use a special reducer built for handling immutable js data
-    const immutableReducers = combineImmutableReducers({ reduxAsyncConnect });
+    const immutableReducers = combineImmutableReducers({
+      reduxAsyncConnect: immutableReducer
+    });
 
     // We need to re-wrap the component so the mapStateToProps expects immutable js data
     const ImmutableWrappedApp = asyncConnect([{

--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import RouterContext from 'react-router/lib/RouterContext';
 import { loadAsyncConnect } from '../helpers/utils';
+import { getMutableState } from '../helpers/state';
 
 export default class AsyncConnect extends Component {
   static propTypes = {
@@ -10,6 +11,7 @@ export default class AsyncConnect extends Component {
     beginGlobalLoad: PropTypes.func.isRequired,
     endGlobalLoad: PropTypes.func.isRequired,
     helpers: PropTypes.any,
+    reloadOnPropsChange: PropTypes.func,
   };
 
   static contextTypes = {
@@ -17,6 +19,7 @@ export default class AsyncConnect extends Component {
   };
 
   static defaultProps = {
+    reloadOnPropsChange() { return true; },
     render(props) {
       return <RouterContext {...props} />;
     },
@@ -44,7 +47,10 @@ export default class AsyncConnect extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.loadAsyncData(nextProps);
+    // Allow a user supplied function to determine if an async reload is necessary
+    if (this.props.reloadOnPropsChange(this.props, nextProps)) {
+      this.loadAsyncData(nextProps);
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -56,7 +62,7 @@ export default class AsyncConnect extends Component {
   }
 
   isLoaded() {
-    return this.context.store.getState().reduxAsyncConnect.loaded;
+    return getMutableState(this.context.store.getState()).reduxAsyncConnect.loaded;
   }
 
   loadAsyncData(props) {

--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -19,7 +19,9 @@ export default class AsyncConnect extends Component {
   };
 
   static defaultProps = {
-    reloadOnPropsChange() { return true; },
+    reloadOnPropsChange() {
+      return true;
+    },
     render(props) {
       return <RouterContext {...props} />;
     },

--- a/modules/containers/decorator.js
+++ b/modules/containers/decorator.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { isPromise } from '../helpers/utils';
 import { load, loadFail, loadSuccess } from '../store';
+import { getMutableState, getImmutableState } from '../helpers/state';
 
 /**
  * Wraps react components with data loaders
@@ -51,6 +52,7 @@ export function asyncConnect(asyncItems, mapStateToProps, mapDispatchToProps, me
     Component.reduxAsyncConnect = wrapWithDispatch(asyncItems);
 
     const finalMapStateToProps = (state, ownProps) => {
+      const mutableState = getMutableState(state);
       const asyncStateToProps = asyncItems.reduce((result, { key }) => {
         if (!key) {
           return result;
@@ -58,7 +60,7 @@ export function asyncConnect(asyncItems, mapStateToProps, mapDispatchToProps, me
 
         return {
           ...result,
-          [key]: state.reduxAsyncConnect[key],
+          [key]: mutableState.reduxAsyncConnect[key],
         };
       }, {});
 
@@ -67,7 +69,7 @@ export function asyncConnect(asyncItems, mapStateToProps, mapDispatchToProps, me
       }
 
       return {
-        ...mapStateToProps(state, ownProps),
+        ...mapStateToProps(getImmutableState(mutableState), ownProps),
         ...asyncStateToProps,
       };
     };

--- a/modules/helpers/state.js
+++ b/modules/helpers/state.js
@@ -1,0 +1,35 @@
+// Global vars holding the custom state conversion methods. Default is just identity methods
+let immutableStateFunc = (state) => state;
+let mutableStateFunc = (state) => state;
+
+/**
+ * Sets the function to be used for converting mutable state to immutable state
+ * @param {Function} func Converts mutable state to immutable state [(state) => state]
+ */
+export function setToImmutableStateFunc(func) {
+  immutableStateFunc = func;
+}
+
+/**
+ * Sets the function to be used for converting immutable state to mutable state
+ * @param {Function} func Converts immutable state to mutable state [(state) => state]
+ */
+export function setToMutableStateFunc(func) {
+  mutableStateFunc = func;
+}
+
+/**
+ * Call when needing to transform mutable data to immutable data using the preset function
+ * @param {Object} state Mutable state thats converted to immutable state by user defined func
+ */
+export function getImmutableState(state) {
+  return immutableStateFunc(state);
+}
+
+/**
+ * Call when needing to transform immutable data to mutable data using the preset function
+ * @param {Immutable} state Immutable state thats converted to mutable state by user defined func
+ */
+export function getMutableState(state) {
+  return mutableStateFunc(state);
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -2,3 +2,4 @@ export ReduxAsyncConnect from './containers/AsyncConnect';
 export { asyncConnect } from './containers/decorator';
 export { loadOnServer } from './helpers/utils';
 export { reducer } from './store';
+export { setToImmutableStateFunc, setToMutableStateFunc } from './helpers/state';

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,5 +1,5 @@
 export ReduxAsyncConnect from './containers/AsyncConnect';
 export { asyncConnect } from './containers/decorator';
 export { loadOnServer } from './helpers/utils';
-export { reducer } from './store';
+export { reducer, immutableReducer } from './store';
 export { setToImmutableStateFunc, setToMutableStateFunc } from './helpers/state';

--- a/modules/store.js
+++ b/modules/store.js
@@ -13,76 +13,75 @@ const initialState = {
   loadState: {},
 };
 
-export const reducer = function reducer(immutableState, action) {
-  // Convert our immutable state to a mutable state (or leave it undefined)
-  const mutableState = immutableState !== undefined ?
-    getMutableState(immutableState) : immutableState;
+const reduxAsyncReducer = handleActions({
+  [BEGIN_GLOBAL_LOAD]: (state) => ({
+    ...state,
+    loaded: false,
+  }),
 
-  const finalState = handleActions({
+  [END_GLOBAL_LOAD]: (state) => ({
+    ...state,
+    loaded: true,
+  }),
 
-    [BEGIN_GLOBAL_LOAD]: (state) => ({
-      ...state,
-      loaded: false,
-    }),
-
-    [END_GLOBAL_LOAD]: (state) => ({
-      ...state,
-      loaded: true,
-    }),
-
-    [LOAD]: (state, { payload }) => ({
-      ...state,
-      loadState: {
-        ...state.loadState,
-        [payload.key]: {
-          loading: true,
-          loaded: false,
-        },
+  [LOAD]: (state, { payload }) => ({
+    ...state,
+    loadState: {
+      ...state.loadState,
+      [payload.key]: {
+        loading: true,
+        loaded: false,
       },
-    }),
+    },
+  }),
 
-    [LOAD_SUCCESS]: (state, { payload: { key, data } }) => ({
-      ...state,
-      loadState: {
-        ...state.loadState,
-        [key]: {
-          loading: false,
-          loaded: true,
-          error: null,
-        },
+  [LOAD_SUCCESS]: (state, { payload: { key, data } }) => ({
+    ...state,
+    loadState: {
+      ...state.loadState,
+      [key]: {
+        loading: false,
+        loaded: true,
+        error: null,
       },
-      [key]: data,
-    }),
+    },
+    [key]: data,
+  }),
 
-    [LOAD_FAIL]: (state, { payload: { key, error } }) => ({
-      ...state,
-      loadState: {
-        ...state.loadState,
-        [key]: {
-          loading: false,
-          loaded: false,
-          error,
-        },
+  [LOAD_FAIL]: (state, { payload: { key, error } }) => ({
+    ...state,
+    loadState: {
+      ...state.loadState,
+      [key]: {
+        loading: false,
+        loaded: false,
+        error,
       },
-    }),
+    },
+  }),
 
-    [CLEAR]: (state, { payload }) => ({
-      ...state,
-      loadState: {
-        ...state.loadState,
-        [payload]: {
-          loading: false,
-          loaded: false,
-          error: null,
-        },
+  [CLEAR]: (state, { payload }) => ({
+    ...state,
+    loadState: {
+      ...state.loadState,
+      [payload]: {
+        loading: false,
+        loaded: false,
+        error: null,
       },
-      [payload]: null,
-    }),
+    },
+    [payload]: null,
+  }),
 
-  }, initialState)(mutableState, action);
+}, initialState);
 
-  // Make sure we return an immutable state if a custom immutable state method is passed
-  return getImmutableState(finalState);
+export const reducer = function wrappedReducer(state, action) {
+  // if state is undefined then it can't be converted to mutable
+  let mutableState = state;
+  if (mutableState !== undefined) {
+    mutableState = getMutableState(state);
+  }
+  return getImmutableState(reduxAsyncReducer(mutableState, action));
 };
 
 export const clearKey = createAction(CLEAR);

--- a/modules/store.js
+++ b/modules/store.js
@@ -13,7 +13,7 @@ const initialState = {
   loadState: {},
 };
 
-const reduxAsyncReducer = handleActions({
+export const reducer = handleActions({
   [BEGIN_GLOBAL_LOAD]: (state) => ({
     ...state,
     loaded: false,
@@ -75,7 +75,7 @@ const reduxAsyncReducer = handleActions({
 
 }, initialState);
 
-export const reducer = function wrappedReducer(immutableState, action) {
+export const immutableReducer = function wrapReducer(immutableState, action) {
   // We need to convert immutable state to mutable state before our reducer can act upon it
   let mutableState;
   if (immutableState === undefined) {
@@ -88,7 +88,7 @@ export const reducer = function wrappedReducer(immutableState, action) {
   }
 
   // Run the reducer and then re-convert the mutable output state back to immutable state
-  return getImmutableState(reduxAsyncReducer(mutableState, action));
+  return getImmutableState(reducer(mutableState, action));
 };
 
 export const clearKey = createAction(CLEAR);

--- a/modules/store.js
+++ b/modules/store.js
@@ -1,4 +1,5 @@
 import { createAction, handleActions } from 'redux-actions';
+import { getMutableState, getImmutableState } from './helpers/state';
 
 export const LOAD = '@reduxAsyncConnect/LOAD';
 export const LOAD_SUCCESS = '@reduxAsyncConnect/LOAD_SUCCESS';
@@ -12,68 +13,77 @@ const initialState = {
   loadState: {},
 };
 
-export const reducer = handleActions({
+export const reducer = function reducer(immutableState, action) {
+  // Convert our immutable state to a mutable state (or leave it undefined)
+  const mutableState = immutableState !== undefined ?
+    getMutableState(immutableState) : immutableState;
 
-  [BEGIN_GLOBAL_LOAD]: (state) => ({
-    ...state,
-    loaded: false,
-  }),
+  const finalState = handleActions({
 
-  [END_GLOBAL_LOAD]: (state) => ({
-    ...state,
-    loaded: true,
-  }),
+    [BEGIN_GLOBAL_LOAD]: (state) => ({
+      ...state,
+      loaded: false,
+    }),
 
-  [LOAD]: (state, { payload }) => ({
-    ...state,
-    loadState: {
-      ...state.loadState,
-      [payload.key]: {
-        loading: true,
-        loaded: false,
+    [END_GLOBAL_LOAD]: (state) => ({
+      ...state,
+      loaded: true,
+    }),
+
+    [LOAD]: (state, { payload }) => ({
+      ...state,
+      loadState: {
+        ...state.loadState,
+        [payload.key]: {
+          loading: true,
+          loaded: false,
+        },
       },
-    },
-  }),
+    }),
 
-  [LOAD_SUCCESS]: (state, { payload: { key, data } }) => ({
-    ...state,
-    loadState: {
-      ...state.loadState,
-      [key]: {
-        loading: false,
-        loaded: true,
-        error: null,
+    [LOAD_SUCCESS]: (state, { payload: { key, data } }) => ({
+      ...state,
+      loadState: {
+        ...state.loadState,
+        [key]: {
+          loading: false,
+          loaded: true,
+          error: null,
+        },
       },
-    },
-    [key]: data,
-  }),
+      [key]: data,
+    }),
 
-  [LOAD_FAIL]: (state, { payload: { key, error } }) => ({
-    ...state,
-    loadState: {
-      ...state.loadState,
-      [key]: {
-        loading: false,
-        loaded: false,
-        error,
+    [LOAD_FAIL]: (state, { payload: { key, error } }) => ({
+      ...state,
+      loadState: {
+        ...state.loadState,
+        [key]: {
+          loading: false,
+          loaded: false,
+          error,
+        },
       },
-    },
-  }),
+    }),
 
-  [CLEAR]: (state, { payload }) => ({
-    ...state,
-    loadState: {
-      ...state.loadState,
-      [payload]: {
-        loading: false,
-        loaded: false,
-        error: null,
+    [CLEAR]: (state, { payload }) => ({
+      ...state,
+      loadState: {
+        ...state.loadState,
+        [payload]: {
+          loading: false,
+          loaded: false,
+          error: null,
+        },
       },
-    },
-    [payload]: null,
-  }),
+      [payload]: null,
+    }),
 
-}, initialState);
+  }, initialState)(mutableState, action);
+
+  // Make sure we return an immutable state if a custom immutable state method is passed
+  return getImmutableState(finalState);
+};
 
 export const clearKey = createAction(CLEAR);
 

--- a/modules/store.js
+++ b/modules/store.js
@@ -75,12 +75,19 @@ const reduxAsyncReducer = handleActions({
 
 }, initialState);
 
-export const reducer = function wrappedReducer(state, action) {
-  // if state is undefined then it can't be converted to mutable
-  let mutableState = state;
-  if (mutableState !== undefined) {
-    mutableState = getMutableState(state);
+export const reducer = function wrappedReducer(immutableState, action) {
+  // We need to convert immutable state to mutable state before our reducer can act upon it
+  let mutableState;
+  if (immutableState === undefined) {
+    // if state is undefined (no initial state yet) then we can't convert it, so let the
+    // reducer set the initial state for us
+    mutableState = immutableState;
+  } else {
+    // Convert immutable state to mutable state so our reducer will accept it
+    mutableState = getMutableState(immutableState);
   }
+
+  // Run the reducer and then re-convert the mutable output state back to immutable state
   return getImmutableState(reduxAsyncReducer(mutableState, action));
 };
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.0.1",
+    "immutable": "^3.8.1",
     "jest-cli": "^12.0.2",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.2",
@@ -59,6 +60,7 @@
     "react-redux": "^4.4.0",
     "react-router": "^2.4.0",
     "redux": "^3.3.1",
+    "redux-immutable": "^3.0.6",
     "sinon": "^1.17.4"
   },
   "dependencies": {


### PR DESCRIPTION
- Added global methods for converting from mutable state to immutable state and back
again
- Added special method for controlling when the ReduxAsyncConnect
component should call `loadAsyncData`
- Added test cases for use with immutablejs

An attempt to resolve #15, but in a generic way that could be used with any immutable lib.

Please see README for detailed usage and examples.

**Usage**
Set two global methods for converting between mutable and immutable store states. Those methods are then wrapped around all state access within redux-connect.

```js
import { setToImmutableStateFunc, setToMutableStateFunc } from 'redux-connect';

// Set the mutability/immutability functions
setToImmutableStateFunc((mutableState) => Immutable.fromJS(mutableState));
setToMutableStateFunc((immutableState) => immutableState.toJS());

// Thats all, now just use redux-connect as normal. 
// These should probably be set in the same file you add reduxAsyncConnect reducer in
```

*Note:* I also needed to add a custom method for determining when to call `loadAsyncData` when using react-router. Without this custom method, I would get infinite looping because `componentWillChangeProps` would always call `loadAsyncData` which would cause the props to change again and re-call `loadAsyncData`. The custom method I used only allows the calling of `loadAsyncData` if route/path has changed. A more detailed example and explanation can be found in README. See https://github.com/Rezonans/redux-async-connect/issues/43 for similar issue.