### PR TITLE
Upgrade react-redux peer dependency to include v5.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "react": "0.14.x || 15.x.x",
     "react-router": "~2.x.x || ~3.x.x",
-    "react-redux": "~4.x.x"
+    "react-redux": "~4.x.x || ~5.x.x"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
Allow versions ~4.x.x and ~5.x.x of react-redux in package.json peerDependencies.