### PR TITLE
chore: update readme client example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,61 +27,76 @@ Using [npm](https://www.npmjs.com/):
 `$ npm install redux-connect -S`
 
 ```js
-import BrowserRouter from 'react-router-dom/BrowserRouter'
-import renderRoutes from 'react-router-config/renderRoutes'
-import { ReduxAsyncConnect, asyncConnect, reducer as reduxAsyncConnect } from 'redux-connect'
-import React from 'react'
-import { hydrate } from 'react-dom'
-import { createStore, combineReducers } from 'redux'
+import { BrowserRouter } from "react-router-dom";
+import { renderRoutes } from "react-router-config";
+import {
+  ReduxAsyncConnect,
+  asyncConnect,
+  reducer as reduxAsyncConnect
+} from "redux-connect";
+import React from "react";
+import { hydrate } from "react-dom";
+import { createStore, combineReducers } from "redux";
+import { Provider } from "react-redux";
 
-// 1. Connect your data, similar to react-redux @connect
-@asyncConnect([{
-  key: 'lunch',
-  promise: ({ match: { params }, helpers }) => Promise.resolve({ id: 1, name: 'Borsch' })
-}])
-class App extends React.Component {
-  render() {
-    // 2. access data as props
-    const { lunch, route } = this.props
+const App = props => {
+  const { route, asyncConnectKeyExample } = props; // access data from asyncConnect as props
+  return (
+    <div>
+      {asyncConnectKeyExample && asyncConnectKeyExample.name}
+      {renderRoutes(route.routes)}
+    </div>
+  );
+};
 
-    return (
-      <div>
-        {lunch.name}
-        {renderRoutes(route.routes)}
-      </div>
-    )
+// Conenect App with asyncConnect
+const ConnectedApp = asyncConnect([
+  // API for ayncConnect decorator: https://github.com/makeomatic/redux-connect/blob/master/docs/API.MD#asyncconnect-decorator
+  {
+    key: "asyncConnectKeyExample",
+    promise: ({ match: { params }, helpers }) =>
+      Promise.resolve({
+        id: 1,
+        name: "value returned from promise for the key asyncConnectKeyExample"
+      })
   }
-}
+])(App);
 
-class Child extends React.component {
-  render() {
-    return (
-      <div>{'child component'}</div>
-    )
+const ChildRoute = () => <div>{"child component"}</div>;
+
+// config route
+const routes = [
+  {
+    path: "/",
+    component: ConnectedApp,
+    routes: [
+      {
+        path: "/child",
+        exact: true,
+        component: ChildRoute
+      }
+    ]
   }
-}
+];
 
-const routes = [{
-  path: '/',
-  component: App,
-  routes: [{
-    path: '/child',
-    exact: true,
-    component: Child,
-  }]
-}]
+// Config store
+const store = createStore(
+  combineReducers({ reduxAsyncConnect }), // Connect redux async reducer
+  window.__data
+);
+window.store = store;
 
-// 2. Connect redux async reducer
-const store = createStore(combineReducers({ reduxAsyncConnect }), window.__data)
-
-// 3. Render `Router` with ReduxAsyncConnect middleware
-hydrate((
+// App Mount point
+hydrate(
   <Provider store={store} key="provider">
     <BrowserRouter>
-      <ReduxAsyncConnect routes={routes} helpers={helpers} />
+      {/** Render `Router` with ReduxAsyncConnect middleware */}
+      <ReduxAsyncConnect routes={routes} />
     </BrowserRouter>
-  </Provider>
-), el)
+  </Provider>,
+  document.getElementById("root")
+);
+
 ```
 
 ### Server


### PR DESCRIPTION
The client side example in the readme is not working. I remade a demo from the example in readme. 

```js
import { BrowserRouter } from "react-router-dom";
import { renderRoutes } from "react-router-config";
import {
  ReduxAsyncConnect,
  asyncConnect,
  reducer as reduxAsyncConnect
} from "redux-connect";
import React from "react";
import { hydrate } from "react-dom";
import { createStore, combineReducers } from "redux";
import { Provider } from "react-redux";

const App = props => {
  const { route, asyncConnectKeyExample } = props; // access data from asyncConnect as props
  return (
    <div>
      {asyncConnectKeyExample && asyncConnectKeyExample.name}
      {renderRoutes(route.routes)}
    </div>
  );
};

// Conenect App with asyncConnect
const ConnectedApp = asyncConnect([
  // API for ayncConnect decorator: https://github.com/makeomatic/redux-connect/blob/master/docs/API.MD#asyncconnect-decorator
  {
    key: "asyncConnectKeyExample",
    promise: ({ match: { params }, helpers }) =>
      Promise.resolve({
        id: 1,
        name: "value returned from promise for the key asyncConnectKeyExample"
      })
  }
])(App);

const ChildRoute = () => <div>{"child component"}</div>;

// config route
const routes = [
  {
    path: "/",
    component: ConnectedApp,
    routes: [
      {
        path: "/child",
        exact: true,
        component: ChildRoute
      }
    ]
  }
];

// Config store
const store = createStore(
  combineReducers({ reduxAsyncConnect }), // Connect redux async reducer
  window.__data
);
window.store = store;

// App Mount point
hydrate(
  <Provider store={store} key="provider">
    <BrowserRouter>
      {/** Render `Router` with ReduxAsyncConnect middleware */}
      <ReduxAsyncConnect routes={routes} />
    </BrowserRouter>
  </Provider>,
  document.getElementById("root")
);

```