### PR TITLE
fix: initial load renders routes immediately

### DIFF
--- a/modules/components/AsyncConnect.js
+++ b/modules/components/AsyncConnect.js
@@ -13,6 +13,7 @@ export class AsyncConnect extends Component {
 
     this.state = {
       previousLocation: this.isLoaded() ? null : props.location,
+      isInitialLoaded: false,
     };
 
     this.mounted = false;
@@ -72,6 +73,12 @@ export class AsyncConnect extends Component {
         this.setState({ previousLocation: null });
       }
 
+      const { isInitialLoaded } = this.state;
+
+      if (!isInitialLoaded) {
+        this.setState({ isInitialLoaded: true });
+      }
+
       // TODO: investigate race conditions
       // do we need to call this if it's not last invocation?
       endGlobalLoad();
@@ -79,15 +86,15 @@ export class AsyncConnect extends Component {
   }
 
   render() {
-    const { previousLocation } = this.state;
+    const { previousLocation, isInitialLoaded } = this.state;
     const { location, render } = this.props;
 
-    return (
+    return isInitialLoaded ? (
       <Route
         location={previousLocation || location}
         render={() => render(this.props)}
       />
-    );
+    ) : null;
   }
 }
 


### PR DESCRIPTION
This fix addresses the issues reported earlier:
https://github.com/makeomatic/redux-connect/issues/129
https://github.com/makeomatic/redux-connect/issues/136

I've created a sandbox example where issue can be reproduced. [Click here](https://codesandbox.io/s/react-connect-issue-6ixom). If you navigate to some nested page route by directly hitting it in browser tab (e.g. https://6ixom.csb.app/page/subpage) you'll see all nested components are rendered immediately where's their promises are not resolved yet.

@AVVS Hope this makes things clear